### PR TITLE
Added DownstreamResponse::aggregate() method

### DIFF
--- a/src/Response/DownstreamResponse.php
+++ b/src/Response/DownstreamResponse.php
@@ -409,4 +409,21 @@ class DownstreamResponse extends BaseResponse implements DownstreamResponseContr
 	{
 		return $this->hasMissingToken;
 	}
+
+    /**
+     * Aggregate two response
+     *
+     * @param DownstreamResponse $response
+     */
+    public function aggregate(DownstreamResponse $response)
+    {
+        $this->numberTokensSuccess += $response->numberSuccess();
+        $this->numberTokensFailure = $response->numberFailure();
+        $this->numberTokenModify = $response->numberModification();
+
+        $this->tokensToDelete = $response->tokensToDelete();
+        $this->tokensToModify = $response->tokensToModify();
+        $this->tokensToRetry = $response->tokensToRetry();
+        $this->tokensWithError = $response->tokensWithError();
+    }
 }

--- a/src/Response/DownstreamResponseContract.php
+++ b/src/Response/DownstreamResponseContract.php
@@ -82,4 +82,11 @@ interface DownstreamResponseContract {
 	 */
 	public function hasMissingToken();
 
+    /**
+     * Aggregate two response
+     *
+     * @param DownstreamResponse $response
+     */
+    public function aggregate(DownstreamResponse $response);
+
 }


### PR DESCRIPTION
While `DownstreamResponse::merge()` is useful when dealing with huge chunk of receivers, `DownstreamResponse::aggregate()` might be useful for users who want to get the final statistics after handling the failed deliveries. For example:

```php
// Not tested pseudo

function fire($to, $options, $notification, $data)
{
	return app('fcm.sender')->sendTo($to, $options, $notification, $data);
}

$to = ["first_token", "second_token", "third_token", "fourth_token", "fifth_token", "sixth_token"];
$options = null;
$noditication = null;
$data = (new PayloadDataBuilder())->addData(['foo' => 'bar']);

$response = fire($to, $options, $notification, $data);

if ($response->numberFailure() > 0 && $response->tokensToRetry()) {
	$retried = fire($response->tokensToRetry(), $options, $notification, $data);
}

$response = $response->aggregate($retried);

var_dump(sprintf(
    "FCM stats: success %d, fail %d, number of modified token %d.",
    $response->numberSuccess(),
    $response->numberFailure(),
    $response->numberModification()
));
```

Thanks.