### PR TITLE
Added support for multiple senders.

### DIFF
--- a/src/Request/BaseRequest.php
+++ b/src/Request/BaseRequest.php
@@ -62,4 +62,18 @@ abstract class BaseRequest
             'json' => $this->buildBody(),
         ];
     }
+
+    /**
+     * Overwrites the server_key and sender_id that is in the .env file.
+     * This allows for multiple senders. If your application supports multiple users/clients, and each client sends its
+     * own notifications, each one has it's own sender_id (and key), so you can save it in the database.
+     *
+     * @param $server_key
+     * @param $sender_id
+     */
+    public function overwriteServerKeyAndSenderId($server_key, $sender_id)
+    {
+        $this->config['server_key'] = $server_key;
+        $this->config['sender_id'] = $sender_id;
+    }
 }

--- a/src/Request/Request.php
+++ b/src/Request/Request.php
@@ -55,8 +55,10 @@ class Request extends BaseRequest
      * @param PayloadNotification $notification
      * @param PayloadData         $data
      * @param Topics|null         $topic
+     * @param string|null         $server_key // overwrites the one in .env file
+     * @param string|null         $sender_id  // overwrites the one in .env file
      */
-    public function __construct($to, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null, Topics $topic = null)
+    public function __construct($to, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null, Topics $topic = null, $server_key = null, $sender_id = null)
     {
         parent::__construct();
 
@@ -65,6 +67,12 @@ class Request extends BaseRequest
         $this->notification = $notification;
         $this->data = $data;
         $this->topic = $topic;
+
+        // If $server_key and $sender_id are passed, overwrite the ones in config
+        // allows for multiple senders
+        if ($server_key && $sender_id) {
+            $this->overwriteServerKeyAndSenderId($server_key, $sender_id);
+        }
     }
 
     /**

--- a/src/Sender/FCMSender.php
+++ b/src/Sender/FCMSender.php
@@ -24,22 +24,26 @@ class FCMSender extends HTTPSender
      *
      * - a unique device with is registration Token
      * - or to multiples devices with an array of registrationIds
+     * - added support to multiple senders, by allowing to overwrite the sender_id and server_key that is in the .env file
+     * for one that comes from the database.
      *
      * @param string|array             $to
      * @param Options|null             $options
      * @param PayloadNotification|null $notification
      * @param PayloadData|null         $data
+     * @param string|null              $server_key // overwrites the one in .env file
+     * @param string|null              $sender_id  // overwrites the one in .env file
      *
      * @return DownstreamResponse|null
      */
-    public function sendTo($to, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null)
+    public function sendTo($to, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null, $server_key = null, $sender_id = null)
     {
         $response = null;
 
         if (is_array($to) && !empty($to)) {
             $partialTokens = array_chunk($to, self::MAX_TOKEN_PER_REQUEST, false);
             foreach ($partialTokens as $tokens) {
-                $request = new Request($tokens, $options, $notification, $data);
+                $request = new Request($tokens, $options, $notification, $data, null, $server_key, $sender_id);
 
                 $responseGuzzle = $this->post($request);
 
@@ -51,7 +55,7 @@ class FCMSender extends HTTPSender
                 }
             }
         } else {
-            $request = new Request($to, $options, $notification, $data);
+            $request = new Request($to, $options, $notification, $data, null, $server_key, $sender_id);
             $responseGuzzle = $this->post($request);
 
             $response = new DownstreamResponse($responseGuzzle, $to);


### PR DESCRIPTION
added support for multiple senders. Instead of having 1 pair of sender_id, server_key set up in the .env configuration file, we can have multiple sets saved in the database. If your applcation has multiple clients/users, and they send their own notifications, from their own (sender_id + server_key pair), this will support that without "hurting" the original way of just one sender.