### PR TITLE
Added event support

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,7 +398,34 @@ $topics->topic('TopicA')
 	       $condition->topic('TopicB')->orTopic('TopicC');
        });
 ```
+## Events
+Instead of reading the response result you can listen to FCM response events:
 
+first add a listener for the events you want to your `App\Providers\EventServiceProvider`
+```php
+//....
+    protected $listen = [
+	//....
+	//Token that must be deleted
+        \LaravelFCM\Events\DeleteToken::class=>[
+            'App\Listeners\DeleteTokenListener',
+        ],
+	//Token that must be updated
+        \LaravelFCM\Events\UpdateToken::class=>[
+            'App\Listeners\UpdateTokenListener',
+        ],
+	//Message that has to be resended
+        \LaravelFCM\Events\Resend::class=>[
+            'App\Listeners\ResendFCMListener',
+        ],
+	//Messages with errors, in production you should delete this tokens
+        \LaravelFCM\Events\WithErrors::class=>[
+            'App\Listeners\FCMWithErrorsListener',
+        ],
+	//....
+   ]
+//....
+```
 
 ## Testing
 

--- a/config/fcm.php
+++ b/config/fcm.php
@@ -15,5 +15,7 @@ return [
 	'events'=>[
 		'updateToken'	=> \LaravelFCM\Events\UpdateToken::class,
 		'deleteToken'	=> \LaravelFCM\Events\DeleteToken::class,
+		'resend'		=> \LaravelFCM\Events\Resend::class,
+		'withErrors'	=> \LaravelFCM\Events\WithErrors::class,
 	],
 ];

--- a/config/fcm.php
+++ b/config/fcm.php
@@ -11,4 +11,9 @@ return [
         'server_group_url' => 'https://android.googleapis.com/gcm/notification',
         'timeout' => 30.0, // in second
     ],
+	
+	'events'=>[
+		'updateToken'	=> \LaravelFCM\Events\UpdateToken::class,
+		'deleteToken'	=> \LaravelFCM\Events\DeleteToken::class,
+	],
 ];

--- a/src/Events/DeleteToken.php
+++ b/src/Events/DeleteToken.php
@@ -15,7 +15,7 @@ class DeleteToken
      * DeleteToken constructor.
      * @param string $token Token to be deleted
      */
-    public function __construct(string $token)
+    public function __construct($token)
     {
 		$this->tokenToBeDeleted=$token;
     }

--- a/src/Events/DeleteToken.php
+++ b/src/Events/DeleteToken.php
@@ -4,15 +4,16 @@ namespace LaravelFCM\Events;
 class DeleteToken
 {
 	public
-		/**@var string**/
+		/**
+         * Token that should be deleted
+         * @var string*
+         */
 		$tokenToBeDeleted;
 
 
     /**
-     * Create a new event instance.
-     *
-     * @param  Order  $order
-     * @return void
+     * DeleteToken constructor.
+     * @param string $token Token to be deleted
      */
     public function __construct(string $token)
     {

--- a/src/Events/DeleteToken.php
+++ b/src/Events/DeleteToken.php
@@ -1,0 +1,21 @@
+<?php
+namespace LaravelFCM\Events;
+
+class DeleteToken
+{
+	public
+		/**@var string**/
+		$tokenToBeDeleted;
+
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  Order  $order
+     * @return void
+     */
+    public function __construct(string $token)
+    {
+		$this->tokenToBeDeleted=$token;
+    }
+}

--- a/src/Events/Resend.php
+++ b/src/Events/Resend.php
@@ -1,0 +1,21 @@
+<?php
+namespace LaravelFCM\Events;
+
+class Resend
+{
+	public
+		/**@var string**/
+		$token;
+
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  Order  $order
+     * @return void
+     */
+    public function __construct(string $token)
+    {
+		$this->token=$token;
+    }
+}

--- a/src/Events/Resend.php
+++ b/src/Events/Resend.php
@@ -21,7 +21,7 @@ class Resend
      * @param PayloadNotification|null $notification
      * @param PayloadData|null $data
      */
-    public function __construct(string $token, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null)
+    public function __construct($token, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null)
     {
 		$this->token = $token;
 		$this->options = $options;

--- a/src/Events/Resend.php
+++ b/src/Events/Resend.php
@@ -7,12 +7,9 @@ class Resend
 		/**@var string**/
 		$token;
 
-
     /**
-     * Create a new event instance.
-     *
-     * @param  Order  $order
-     * @return void
+     * Resend constructor.
+     * @param string $token Token that should be resended
      */
     public function __construct(string $token)
     {

--- a/src/Events/Resend.php
+++ b/src/Events/Resend.php
@@ -1,18 +1,31 @@
 <?php
 namespace LaravelFCM\Events;
 
+use LaravelFCM\Message\Options;
+use LaravelFCM\Message\PayloadData;
+use LaravelFCM\Message\PayloadNotification;
+
 class Resend
 {
 	public
 		/**@var string**/
-		$token;
+		$token,
+        $options = null,
+        $notification = null,
+        $data = null;
 
     /**
      * Resend constructor.
-     * @param string $token Token that should be resended
+     * @param string $token Destination token that should be resended
+     * @param Options|null $options
+     * @param PayloadNotification|null $notification
+     * @param PayloadData|null $data
      */
-    public function __construct(string $token)
+    public function __construct(string $token, Options $options = null, PayloadNotification $notification = null, PayloadData $data = null)
     {
-		$this->token=$token;
+		$this->token = $token;
+		$this->options = $options;
+		$this->notification = $notification;
+		$this->data = $data;
     }
 }

--- a/src/Events/UpdateToken.php
+++ b/src/Events/UpdateToken.php
@@ -1,0 +1,24 @@
+<?php
+namespace LaravelFCM\Events;
+
+class UpdateToken
+{
+	public
+		/**@var string**/
+		$originalToken,
+		/**@var string**/
+		$newToken;
+
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  Order  $order
+     * @return void
+     */
+    public function __construct(string $originalToken,string $newToken)
+    {
+		$this->originalToken=$originalToken;
+		$this->newToken=$newToken;
+    }
+}

--- a/src/Events/UpdateToken.php
+++ b/src/Events/UpdateToken.php
@@ -4,17 +4,22 @@ namespace LaravelFCM\Events;
 class UpdateToken
 {
 	public
-		/**@var string**/
+		/**
+         * Original token to be replaced
+         * @var string*
+         */
 		$originalToken,
-		/**@var string**/
+		/**
+         * New token that should be used
+         * @var string*
+         */
 		$newToken;
 
 
     /**
-     * Create a new event instance.
-     *
-     * @param  Order  $order
-     * @return void
+     * UpdateToken constructor.
+     * @param string $originalToken Original token (to be replaced with $newToken)
+     * @param string $newToken Updated token
      */
     public function __construct(string $originalToken,string $newToken)
     {

--- a/src/Events/UpdateToken.php
+++ b/src/Events/UpdateToken.php
@@ -21,7 +21,7 @@ class UpdateToken
      * @param string $originalToken Original token (to be replaced with $newToken)
      * @param string $newToken Updated token
      */
-    public function __construct(string $originalToken,string $newToken)
+    public function __construct($originalToken,$newToken)
     {
 		$this->originalToken=$originalToken;
 		$this->newToken=$newToken;

--- a/src/Events/WithErrors.php
+++ b/src/Events/WithErrors.php
@@ -1,0 +1,23 @@
+<?php
+namespace LaravelFCM\Events;
+
+class WithErrors
+{
+	public
+		/**@var string**/
+		$token,
+		$errors;
+
+
+    /**
+     * Create a new event instance.
+     *
+     * @param  Order  $order
+     * @return void
+     */
+    public function __construct(string $token,$errors)
+    {
+		$this->token	= $token;
+		$this->errors 	= $errors;
+    }
+}

--- a/src/Events/WithErrors.php
+++ b/src/Events/WithErrors.php
@@ -4,16 +4,22 @@ namespace LaravelFCM\Events;
 class WithErrors
 {
 	public
-		/**@var string**/
+		/**
+         * Token that generated the errors
+         * @var string
+         **/
 		$token,
+        /**
+         * Errors
+         * @var mixed
+         */
 		$errors;
 
 
     /**
-     * Create a new event instance.
-     *
-     * @param  Order  $order
-     * @return void
+     * WithErrors constructor.
+     * @param string $token Token with errors
+     * @param mixed $errors Errors encountered
      */
     public function __construct(string $token,$errors)
     {

--- a/src/Events/WithErrors.php
+++ b/src/Events/WithErrors.php
@@ -21,7 +21,7 @@ class WithErrors
      * @param string $token Token with errors
      * @param mixed $errors Errors encountered
      */
-    public function __construct(string $token,$errors)
+    public function __construct($token,$errors)
     {
 		$this->token	= $token;
 		$this->errors 	= $errors;

--- a/src/Response/DownstreamResponse.php
+++ b/src/Response/DownstreamResponse.php
@@ -410,42 +410,4 @@ class DownstreamResponse extends BaseResponse implements DownstreamResponseContr
     {
         return $this->hasMissingToken;
     }
-<<<<<<< HEAD
-
-	/**
-	* Dispatch the events
-	**/
-	protected function dispatchEvents(){
-		// To be deleted
-		$cl = config('fcm.events.deleteToken');
-		if($cl){
-			foreach($this->tokensToDelete() AS $token){
-				event(new $cl($token));
-			}
-		}
-		// To be updated
-		$cl = config('fcm.events.updateToken');
-		if($cl){
-			foreach($this->tokensToModify() AS $oldToken=>$newToken){
-                event(new $cl($oldToken,$newToken));
-			}
-		}
-		// To be resended
-		$cl = config('fcm.events.resend');
-		if($cl){
-			foreach($this->tokensToRetry() AS $token){
-                event(new $cl($token));
-			}
-		}
-		// With errors
-		$cl = config('fcm.events.withErrors');
-		if($cl){
-			foreach($this->tokensWithError() AS $token=>$errors){
-                event(new $cl($token,$errors));
-			}
-		}
-
-	}
-=======
->>>>>>> parent of 429fb80... Added events stub
 }

--- a/src/Response/DownstreamResponse.php
+++ b/src/Response/DownstreamResponse.php
@@ -413,7 +413,7 @@ class DownstreamResponse extends BaseResponse implements DownstreamResponseContr
     {
         return $this->hasMissingToken;
     }
-	
+
 	/**
 	* Dispatch the events
 	**/
@@ -422,30 +422,30 @@ class DownstreamResponse extends BaseResponse implements DownstreamResponseContr
 		$cl = config('fcm.events.deleteToken');
 		if($cl){
 			foreach($this->tokensToDelete() AS $token){
-				emit(new $cl($token));
+				event(new $cl($token));
 			}
 		}
 		// To be updated
 		$cl = config('fcm.events.updateToken');
 		if($cl){
 			foreach($this->tokensToModify() AS $oldToken=>$newToken){
-				emit(new $cl($oldToken,$newToken));
+                event(new $cl($oldToken,$newToken));
 			}
 		}
 		// To be resended
 		$cl = config('fcm.events.resend');
 		if($cl){
 			foreach($this->tokensToRetry() AS $token){
-				emit(new $cl($token));
+                event(new $cl($token));
 			}
 		}
 		// With errors
 		$cl = config('fcm.events.withErrors');
 		if($cl){
 			foreach($this->tokensWithError() AS $token=>$errors){
-				emit(new $cl($token,$errors));
+                event(new $cl($token,$errors));
 			}
 		}
-	
+
 	}
 }

--- a/src/Response/DownstreamResponse.php
+++ b/src/Response/DownstreamResponse.php
@@ -104,9 +104,6 @@ class DownstreamResponse extends BaseResponse implements DownstreamResponseContr
         $this->tokens = is_string($tokens) ? [$tokens] : $tokens;
 
         parent::__construct($response);
-		
-		//Dispatch events
-		$this->dispatchEvents();
     }
 
     /**
@@ -413,6 +410,7 @@ class DownstreamResponse extends BaseResponse implements DownstreamResponseContr
     {
         return $this->hasMissingToken;
     }
+<<<<<<< HEAD
 
 	/**
 	* Dispatch the events
@@ -448,4 +446,6 @@ class DownstreamResponse extends BaseResponse implements DownstreamResponseContr
 		}
 
 	}
+=======
+>>>>>>> parent of 429fb80... Added events stub
 }


### PR DESCRIPTION
Added Laravel event triggering to handle FCM response events.
Due to non-uniformed response pattern only sendTo method will trigger those events but can be easly exended ( see LaravelFCM\Sender\FCMSender\dispatchEvents method implementation)