### PR TITLE
Changed the visibility of the method FCMSender::post

### DIFF
--- a/src/Sender/FCMSender.php
+++ b/src/Sender/FCMSender.php
@@ -105,7 +105,7 @@ class FCMSender extends HTTPSender
      *
      * @return null|\Psr\Http\Message\ResponseInterface
      */
-    private function post($request)
+    protected function post($request)
     {
         try {
             $responseGuzzle = $this->client->request('post', $this->url, $request->build());


### PR DESCRIPTION
Changed the visibility of the method \LaravelFCM\Sender\FCMSender::post, from private to protected in order to be able to override it