### PR TITLE
Add image support on notification fixes #166

### DIFF
--- a/src/Message/PayloadNotification.php
+++ b/src/Message/PayloadNotification.php
@@ -42,6 +42,13 @@ class PayloadNotification implements Arrayable
      *
      * @var null|string
      */
+    protected $image;
+
+    /**
+     * @internal
+     *
+     * @var null|string
+     */
     protected $sound;
 
     /**
@@ -111,6 +118,7 @@ class PayloadNotification implements Arrayable
         $this->body = $builder->getBody();
         $this->channelId = $builder->getChannelId();
         $this->icon = $builder->getIcon();
+        $this->image = $builder->getImage();
         $this->sound = $builder->getSound();
         $this->badge = $builder->getBadge();
         $this->tag = $builder->getTag();
@@ -134,6 +142,7 @@ class PayloadNotification implements Arrayable
             'body' => $this->body,
             'android_channel_id' => $this->channelId,
             'icon' => $this->icon,
+            'image' => $this->image,
             'sound' => $this->sound,
             'badge' => $this->badge,
             'tag' => $this->tag,

--- a/src/Message/PayloadNotificationBuilder.php
+++ b/src/Message/PayloadNotificationBuilder.php
@@ -37,6 +37,13 @@ class PayloadNotificationBuilder
      *
      * @var null|string
      */
+    protected $image;
+
+    /**
+     * @internal
+     *
+     * @var null|string
+     */
     protected $sound;
 
     /**
@@ -168,6 +175,21 @@ class PayloadNotificationBuilder
         $this->icon = $icon;
 
         return $this;
+    }
+
+    /**
+     * Indicates the image that can be displayed in the notification
+     * Supports an url or internal image.
+     *
+     * @param $image
+     *
+     * @return string|null
+     */
+    public function setImage($image)
+    {
+        $this->image = $image;
+
+        return $this->image;
     }
 
     /**
@@ -343,6 +365,16 @@ class PayloadNotificationBuilder
     public function getIcon()
     {
         return $this->icon;
+    }
+
+    /**
+     * Get Image.
+     *
+     * @return string|null
+     */
+    public function getImage()
+    {
+        return $this->image;
     }
 
     /**

--- a/tests/MessageTest.php
+++ b/tests/MessageTest.php
@@ -85,7 +85,8 @@ class PayloadTest extends FCMTestCase
 					"title":"test_title",
 					"body":"test_body",
 					"badge":"test_badge",
-					"sound":"test_sound"
+					"sound":"test_sound",
+					"image":"test_image"
 				}';
 
         $targetFull = '{
@@ -101,7 +102,8 @@ class PayloadTest extends FCMTestCase
 					"body_loc_args":"[ body0, body1 ]",
 					"title_loc_key":"test_title_key",
 					"title_loc_args":"[ title0, title1 ]",
-					"icon":"test_icon"
+					"icon":"test_icon",
+					"image":"test_image"
 				}';
 
         $notificationBuilder = new PayloadNotificationBuilder();
@@ -109,7 +111,8 @@ class PayloadTest extends FCMTestCase
         $notificationBuilder->setTitle('test_title')
                     ->setBody('test_body')
                     ->setSound('test_sound')
-                    ->setBadge('test_badge');
+                    ->setBadge('test_badge')
+                    ->setImage('test_image');
 
         $json = json_encode($notificationBuilder->build()->toArray());
         $this->assertJsonStringEqualsJsonString($targetPartial, $json);
@@ -123,7 +126,8 @@ class PayloadTest extends FCMTestCase
                     ->setBodyLocationArgs('[ body0, body1 ]')
                     ->setTitleLocationKey('test_title_key')
                     ->setTitleLocationArgs('[ title0, title1 ]')
-                    ->setIcon('test_icon');
+                    ->setIcon('test_icon')
+                    ->setImage('test_image');
 
         $json = json_encode($notificationBuilder->build()->toArray());
         $this->assertJsonStringEqualsJsonString($targetFull, $json);


### PR DESCRIPTION
Support for images on notification activated and unit tests expanded

<img width="395" alt="2020-01-07 12 14 01" src="https://user-images.githubusercontent.com/59653108/71986032-05793200-322c-11ea-8b45-5c6935c33696.png">
<img width="405" alt="2020-01-07 12 15 18" src="https://user-images.githubusercontent.com/59653108/71986033-05793200-322c-11ea-9111-7a58788b29b1.png">
