### PR TITLE
Support Laravel 7 and Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": "5.*|^6",
+        "illuminate/support": "5.*|^6|^7|^8",
         "guzzlehttp/guzzle": "~6.0",
         "monolog/monolog": "^1.12|^2.0"
     },


### PR DESCRIPTION
This pull request adjusts the version constraints of this package to support Laravel 7 and Laravel 8, as the newest version of this package currently supports Laravel 6 which is getting pretty old now.

Let me know if you'd like me to make any updates to this pull request.